### PR TITLE
Change: move logs into database

### DIFF
--- a/ShioriArchive.pro
+++ b/ShioriArchive.pro
@@ -132,8 +132,10 @@ SOURCES += src/main.cpp \
     src/core/data_set_files/image_data_set_file.cpp \
     src/core/data_set_files/table_data_set_file.cpp \
     src/core/temp_file_handler.cpp \
+    src/database/audit_log_table.cpp \
     src/database/cluster_snapshot_table.cpp \
     src/database/data_set_table.cpp \
+    src/database/error_log_table.cpp \
     src/database/request_result_table.cpp \
     src/shiori_root.cpp
 
@@ -163,8 +165,10 @@ HEADERS += \
     src/core/data_set_files/image_data_set_file.h \
     src/core/data_set_files/table_data_set_file.h \
     src/core/temp_file_handler.h \
+    src/database/audit_log_table.h \
     src/database/cluster_snapshot_table.h \
     src/database/data_set_table.h \
+    src/database/error_log_table.h \
     src/database/request_result_table.h \
     src/shiori_root.h \
     ../libKitsunemimiHanamiMessages/hanami_messages/shiori_messages.h

--- a/src/config.h
+++ b/src/config.h
@@ -36,8 +36,6 @@ registerConfigs(Kitsunemimi::ErrorContainer &error)
     Kitsunemimi::Hanami::registerBasicConfigs(error);
 
     REGISTER_STRING_CONFIG( "shiori", "data_set_location",         error, "", true );
-    REGISTER_STRING_CONFIG( "shiori", "error_location",            error, "", true );
-    REGISTER_STRING_CONFIG( "shiori", "audit_location",            error, "", true );
     REGISTER_STRING_CONFIG( "shiori", "cluster_snapshot_location", error, "", true );
 }
 

--- a/src/database/audit_log_table.cpp
+++ b/src/database/audit_log_table.cpp
@@ -1,0 +1,181 @@
+/**
+ * @file        audit_log_table.cpp
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2021 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#include <database/audit_log_table.h>
+
+#include <libKitsunemimiCommon/items/table_item.h>
+#include <libKitsunemimiCommon/methods/string_methods.h>
+#include <libKitsunemimiJson/json_item.h>
+
+#include <libKitsunemimiSakuraDatabase/sql_database.h>
+
+/**
+ * @brief constructor
+ *
+ * @param db pointer to database
+ */
+AuditLogTable::AuditLogTable(Kitsunemimi::Sakura::SqlDatabase* db)
+    : HanamiSqlLogTable(db)
+{
+    m_tableName = "audit_log";
+
+    DbHeaderEntry userid;
+    userid.name = "user_id";
+    userid.maxLength = 256;
+    m_tableHeader.push_back(userid);
+
+    DbHeaderEntry endpoint;
+    endpoint.name = "endpoint";
+    endpoint.maxLength = 1024;
+    m_tableHeader.push_back(endpoint);
+
+    DbHeaderEntry component;
+    component.name = "component";
+    component.maxLength = 128;
+    m_tableHeader.push_back(component);
+
+    DbHeaderEntry requestType;
+    requestType.name = "request_type";
+    requestType.maxLength = 16;
+    m_tableHeader.push_back(requestType);
+}
+
+/**
+ * @brief destructor
+ */
+AuditLogTable::~AuditLogTable() {}
+
+/**
+ * @brief add new audit-log-entry into the database
+ *
+ * @param timestamp UTC-timestamp of the request as string
+ * @param userId id of the user, who made the request
+ * @param component requested componen
+ * @param endpoint requested endpoint
+ * @param requestType HTTP-type of the request
+ * @param error reference for error-output
+ *
+ * @return true, if successful, else false
+ */
+bool
+AuditLogTable::addAuditLogEntry(const std::string &timestamp,
+                                const std::string &userId,
+                                const std::string &component,
+                                const std::string &endpoint,
+                                const std::string &requestType,
+                                Kitsunemimi::ErrorContainer &error)
+{
+    Kitsunemimi::Json::JsonItem data;
+    data.insert("timestamp", timestamp);
+    data.insert("user_id", userId);
+    data.insert("component", component);
+    data.insert("endpoint", endpoint);
+    data.insert("requestType", requestType);
+
+    if(add(data, error) == false)
+    {
+        error.addMeesage("Failed to add audit-log-entry to database");
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief get a specific audit-log-entry from the database
+ *
+ * @param result reference for the result-output
+ * @param errorLogEntryUuid uuid of the data
+ * @param error reference for error-output
+ * @param showHiddenValues set to true to also show as hidden marked fields
+ *
+ * @return true, if successful, else false
+ */
+bool
+AuditLogTable::getAuditLogEntry(Kitsunemimi::Json::JsonItem &result,
+                                const std::string &errorLogEntryUuid,
+                                Kitsunemimi::ErrorContainer &error,
+                                const bool showHiddenValues)
+{
+    // get user from db
+    std::vector<RequestCondition> conditions;
+    conditions.emplace_back("uuid", errorLogEntryUuid);
+
+    // get dataset from db
+    if(get(result, conditions, error, showHiddenValues) == false)
+    {
+        error.addMeesage("Failed to get audit-log-entry with UUID '"
+                         + errorLogEntryUuid
+                         + "' from database");
+        LOG_ERROR(error);
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief get all audit-log-entries from the database
+ *
+ * @param result reference for the result-output
+ * @param error reference for error-output
+ *
+ * @return true, if successful, else false
+ */
+bool
+AuditLogTable::getAllAuditLogEntries(Kitsunemimi::TableItem &result,
+                                     Kitsunemimi::ErrorContainer &error)
+{
+    std::vector<RequestCondition> conditions;
+    if(getAll(result, conditions, error, true) == false)
+    {
+        error.addMeesage("Failed to get all audit-log-entries from database");
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief delete audit-log-entry from the database
+ *
+ * @param errorLogEntryUuid uuid of the data
+ * @param error reference for error-output
+ *
+ * @return true, if successful, else false
+ */
+bool
+AuditLogTable::deleteAuditLogEntry(const std::string &errorLogEntryUuid,
+                                   Kitsunemimi::ErrorContainer &error)
+{
+    std::vector<RequestCondition> conditions;
+    conditions.emplace_back("uuid", errorLogEntryUuid);
+    if(del(conditions, error) == false)
+    {
+        error.addMeesage("Failed to delete audit-log-entry with UUID '"
+                         + errorLogEntryUuid
+                         + "' from database");
+        return false;
+    }
+
+    return true;
+}

--- a/src/database/audit_log_table.h
+++ b/src/database/audit_log_table.h
@@ -1,0 +1,58 @@
+/**
+ * @file        audit_log_table.h
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2021 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#ifndef SHIORIARCHIVE_AUDIT_LOG_TABLE_H
+#define SHIORIARCHIVE_AUDIT_LOG_TABLE_H
+
+#include <libKitsunemimiCommon/logger.h>
+#include <libKitsunemimiHanamiDatabase/hanami_sql_log_table.h>
+
+namespace Kitsunemimi {
+namespace Json {
+class JsonItem;
+}
+}
+
+class AuditLogTable
+        : public Kitsunemimi::Hanami::HanamiSqlLogTable
+{
+public:
+    AuditLogTable(Kitsunemimi::Sakura::SqlDatabase* db);
+    ~AuditLogTable();
+
+    bool addAuditLogEntry(const std::string &timestamp,
+                          const std::string &userId,
+                          const std::string &component,
+                          const std::string &endpoint,
+                          const std::string &requestType,
+                          Kitsunemimi::ErrorContainer &error);
+    bool getAuditLogEntry(Kitsunemimi::Json::JsonItem &result,
+                          const std::string &errorLogEntryUuid,
+                          Kitsunemimi::ErrorContainer &error,
+                          const bool showHiddenValues);
+    bool getAllAuditLogEntries(Kitsunemimi::TableItem &result,
+                               Kitsunemimi::ErrorContainer &error);
+    bool deleteAuditLogEntry(const std::string &errorLogEntryUuid,
+                             Kitsunemimi::ErrorContainer &error);
+};
+
+#endif // SHIORIARCHIVE_AUDIT_LOG_TABLE_H

--- a/src/database/cluster_snapshot_table.cpp
+++ b/src/database/cluster_snapshot_table.cpp
@@ -65,7 +65,7 @@ ClusterSnapshotTable::ClusterSnapshotTable(Kitsunemimi::Sakura::SqlDatabase* db)
 ClusterSnapshotTable::~ClusterSnapshotTable() {}
 
 /**
- * @brief add new metadata of a dataset into the database
+ * @brief add new metadata of a snapshot into the database
  *
  * @param userData json-item with all information of the data to add to database
  * @param userContext context-object with all user specific information
@@ -88,7 +88,7 @@ ClusterSnapshotTable::addClusterSnapshot(Kitsunemimi::Json::JsonItem &data,
 }
 
 /**
- * @brief get a metadata-entry for a specific dataset from the database
+ * @brief get a metadata-entry for a specific snapshot from the database
  *
  * @param result reference for the result-output
  * @param snapshotUuid uuid of the data
@@ -123,7 +123,7 @@ ClusterSnapshotTable::getClusterSnapshot(Kitsunemimi::Json::JsonItem &result,
 }
 
 /**
- * @brief get metadata of all datasets from the database
+ * @brief get metadata of all snapshots from the database
  *
  * @param result reference for the result-output
  * @param userContext context-object with all user specific information
@@ -147,7 +147,7 @@ ClusterSnapshotTable::getAllClusterSnapshot(Kitsunemimi::TableItem &result,
 }
 
 /**
- * @brief delete metadata of a dataset from the database
+ * @brief delete metadata of a snapshot from the database
  *
  * @param snapshotUuid uuid of the data
  * @param userContext context-object with all user specific information

--- a/src/database/cluster_snapshot_table.h
+++ b/src/database/cluster_snapshot_table.h
@@ -1,5 +1,5 @@
 /**
- * @file        data_set_table.h
+ * @file        cluster_snapshot_table.h
  *
  * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
  *

--- a/src/database/error_log_table.cpp
+++ b/src/database/error_log_table.cpp
@@ -1,0 +1,186 @@
+/**
+ * @file        error_log_table.cpp
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2021 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#include <database/error_log_table.h>
+
+#include <libKitsunemimiCommon/items/table_item.h>
+#include <libKitsunemimiCommon/methods/string_methods.h>
+#include <libKitsunemimiJson/json_item.h>
+
+#include <libKitsunemimiSakuraDatabase/sql_database.h>
+
+/**
+ * @brief constructor
+ *
+ * @param db pointer to database
+ */
+ErrorLogTable::ErrorLogTable(Kitsunemimi::Sakura::SqlDatabase* db)
+    : HanamiSqlLogTable(db)
+{
+    m_tableName = "error_log";
+
+    DbHeaderEntry userid;
+    userid.name = "user_id";
+    userid.maxLength = 256;
+    m_tableHeader.push_back(userid);
+
+    DbHeaderEntry component;
+    component.name = "component";
+    component.maxLength = 128;
+    m_tableHeader.push_back(component);
+
+    DbHeaderEntry context;
+    context.name = "context";
+    m_tableHeader.push_back(context);
+
+    DbHeaderEntry values;
+    values.name = "values";
+    m_tableHeader.push_back(values);
+
+    DbHeaderEntry message;
+    message.name = "message";
+    m_tableHeader.push_back(message);
+}
+
+/**
+ * @brief destructor
+ */
+ErrorLogTable::~ErrorLogTable() {}
+
+/**
+ * @brief add new error-log-entry into the database
+ *
+ * @param timestamp UTC-timestamp of the error
+ * @param userid id of the user, who had the error
+ * @param component component, where the error appeared
+ * @param context
+ * @param values
+ * @param message
+ * @param error reference for error-output
+ *
+ * @return true, if successful, else false
+ */
+bool
+ErrorLogTable::addErrorLogEntry(const std::string &timestamp,
+                                const std::string &userid,
+                                const std::string &component,
+                                const std::string &context,
+                                const std::string &values,
+                                const std::string &message,
+                                Kitsunemimi::ErrorContainer &error)
+{
+    Kitsunemimi::Json::JsonItem data;
+    data.insert("timestamp", timestamp);
+    data.insert("user_id", userid);
+    data.insert("component", component);
+    data.insert("context", context);
+    data.insert("values", values);
+    data.insert("message", message);
+
+    if(add(data, error) == false)
+    {
+        error.addMeesage("Failed to add error-log-entry to database");
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief get a specific error-log-entry from the database
+ *
+ * @param result reference for the result-output
+ * @param errorLogEntryUuid uuid of the data
+ * @param error reference for error-output
+ * @param showHiddenValues set to true to also show as hidden marked fields
+ *
+ * @return true, if successful, else false
+ */
+bool
+ErrorLogTable::getErrorLogEntry(Kitsunemimi::Json::JsonItem &result,
+                                const std::string &errorLogEntryUuid,
+                                Kitsunemimi::ErrorContainer &error,
+                                const bool showHiddenValues)
+{
+    // get user from db
+    std::vector<RequestCondition> conditions;
+    conditions.emplace_back("uuid", errorLogEntryUuid);
+
+    // get dataset from db
+    if(get(result, conditions, error, showHiddenValues) == false)
+    {
+        error.addMeesage("Failed to get error-log-entry with UUID '"
+                         + errorLogEntryUuid
+                         + "' from database");
+        LOG_ERROR(error);
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief get all error-log-entries from the database
+ *
+ * @param result reference for the result-output
+ * @param error reference for error-output
+ *
+ * @return true, if successful, else false
+ */
+bool
+ErrorLogTable::getAllErrorLogEntries(Kitsunemimi::TableItem &result,
+                                     Kitsunemimi::ErrorContainer &error)
+{
+    std::vector<RequestCondition> conditions;
+    if(getAll(result, conditions, error, true) == false)
+    {
+        error.addMeesage("Failed to get all error-log-entries from database");
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief delete error-log-entry from the database
+ *
+ * @param errorLogEntryUuid uuid of the data
+ * @param error reference for error-output
+ *
+ * @return true, if successful, else false
+ */
+bool
+ErrorLogTable::deleteErrorLogEntry(const std::string &errorLogEntryUuid,
+                                   Kitsunemimi::ErrorContainer &error)
+{
+    std::vector<RequestCondition> conditions;
+    conditions.emplace_back("uuid", errorLogEntryUuid);
+    if(del(conditions, error) == false)
+    {
+        error.addMeesage("Failed to delete error-log-entry with UUID '"
+                         + errorLogEntryUuid
+                         + "' from database");
+        return false;
+    }
+
+    return true;
+}

--- a/src/database/error_log_table.h
+++ b/src/database/error_log_table.h
@@ -1,0 +1,59 @@
+/**
+ * @file        error_log_table.h
+ *
+ * @author      Tobias Anker <tobias.anker@kitsunemimi.moe>
+ *
+ * @copyright   Apache License Version 2.0
+ *
+ *      Copyright 2021 Tobias Anker
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#ifndef SHIORIARCHIVE_ERROR_LOG_TABLE_H
+#define SHIORIARCHIVE_ERROR_LOG_TABLE_H
+
+#include <libKitsunemimiCommon/logger.h>
+#include <libKitsunemimiHanamiDatabase/hanami_sql_log_table.h>
+
+namespace Kitsunemimi {
+namespace Json {
+class JsonItem;
+}
+}
+
+class ErrorLogTable
+        : public Kitsunemimi::Hanami::HanamiSqlLogTable
+{
+public:
+    ErrorLogTable(Kitsunemimi::Sakura::SqlDatabase* db);
+    ~ErrorLogTable();
+
+    bool addErrorLogEntry(const std::string &timestamp,
+                          const std::string &userid,
+                          const std::string &component,
+                          const std::string &context,
+                          const std::string &values,
+                          const std::string &message,
+                          Kitsunemimi::ErrorContainer &error);
+    bool getErrorLogEntry(Kitsunemimi::Json::JsonItem &result,
+                          const std::string &errorLogEntryUuid,
+                          Kitsunemimi::ErrorContainer &error,
+                          const bool showHiddenValues);
+    bool getAllErrorLogEntries(Kitsunemimi::TableItem &result,
+                               Kitsunemimi::ErrorContainer &error);
+    bool deleteErrorLogEntry(const std::string &errorLogEntryUuid,
+                             Kitsunemimi::ErrorContainer &error);
+};
+
+#endif // SHIORIARCHIVE_ERROR_LOG_TABLE_H

--- a/src/shiori_root.cpp
+++ b/src/shiori_root.cpp
@@ -28,6 +28,8 @@
 #include <database/data_set_table.h>
 #include <database/cluster_snapshot_table.h>
 #include <database/request_result_table.h>
+#include <database/error_log_table.h>
+#include <database/audit_log_table.h>
 #include <core/temp_file_handler.h>
 #include <api/blossom_initializing.h>
 
@@ -35,6 +37,8 @@ TempFileHandler* ShioriRoot::tempFileHandler = nullptr;
 DataSetTable* ShioriRoot::dataSetTable = nullptr;
 ClusterSnapshotTable* ShioriRoot::clusterSnapshotTable = nullptr;
 RequestResultTable* ShioriRoot::requestResultTable = nullptr;
+ErrorLogTable* ShioriRoot::errorLogTable = nullptr;
+AuditLogTable* ShioriRoot::auditLogTable = nullptr;
 Kitsunemimi::Sakura::SqlDatabase* ShioriRoot::database = nullptr;
 
 ShioriRoot::ShioriRoot() {}
@@ -91,6 +95,24 @@ ShioriRoot::init()
     if(clusterSnapshotTable->initTable(error) == false)
     {
         error.addMeesage("Failed to initialize cluster-snapshot-table in database.");
+        LOG_ERROR(error);
+        return false;
+    }
+
+    // initialize error-log-table
+    errorLogTable = new ErrorLogTable(database);
+    if(errorLogTable->initTable(error) == false)
+    {
+        error.addMeesage("Failed to initialize error-log-table in database.");
+        LOG_ERROR(error);
+        return false;
+    }
+
+    // initialize audit-log-table
+    auditLogTable = new AuditLogTable(database);
+    if(auditLogTable->initTable(error) == false)
+    {
+        error.addMeesage("Failed to initialize audit-log-table in database.");
         LOG_ERROR(error);
         return false;
     }

--- a/src/shiori_root.h
+++ b/src/shiori_root.h
@@ -31,6 +31,8 @@ class SqlDatabase;
 class DataSetTable;
 class ClusterSnapshotTable;
 class RequestResultTable;
+class ErrorLogTable;
+class AuditLogTable;
 class TempFileHandler;
 
 class ShioriRoot
@@ -44,6 +46,8 @@ public:
     static DataSetTable* dataSetTable;
     static ClusterSnapshotTable* clusterSnapshotTable;
     static RequestResultTable* requestResultTable;
+    static ErrorLogTable* errorLogTable;
+    static AuditLogTable* auditLogTable;
     static Kitsunemimi::Sakura::SqlDatabase* database;
 };
 


### PR DESCRIPTION
## Description

Move audit- and error-log from text-file to its own database-tables

## Related Issues

- #15 

## How it was tested?

- Tsugumi with manually checking of the new database entries
